### PR TITLE
Pin to v1 instead of main

### DIFF
--- a/.github/workflows/bacon-deploy-preview.yml
+++ b/.github/workflows/bacon-deploy-preview.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: jungaretti/bacon-deploy-action@main
+      - uses: jungaretti/bacon-deploy-action@v1
         name: Deploy jungaretti.com
         with:
           api-key: ${{ secrets.PORKBUN_API_KEY }}
@@ -18,7 +18,7 @@ jobs:
           config: dns/jungaretti.com.yml
           create: false
           delete: false
-      - uses: jungaretti/bacon-deploy-action@main
+      - uses: jungaretti/bacon-deploy-action@v1
         name: Deploy jamesungaretti.com
         with:
           api-key: ${{ secrets.PORKBUN_API_KEY }}

--- a/.github/workflows/bacon-deploy.yml
+++ b/.github/workflows/bacon-deploy.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: jungaretti/bacon-deploy-action@main
+      - uses: jungaretti/bacon-deploy-action@v1
         name: Deploy jungaretti.com
         with:
           api-key: ${{ secrets.PORKBUN_API_KEY }}
@@ -19,7 +19,7 @@ jobs:
           config: dns/jungaretti.com.yml
           create: true
           delete: true
-      - uses: jungaretti/bacon-deploy-action@main
+      - uses: jungaretti/bacon-deploy-action@v1
         name: Deploy jamesungaretti.com
         with:
           api-key: ${{ secrets.PORKBUN_API_KEY }}


### PR DESCRIPTION
Housekeeping to pin bacon-deploy-action at `v1` instead of `main`